### PR TITLE
Where-Object -Property Version -NotLike "*esr*"

### DIFF
--- a/Mozilla/Firefox/Install.ps1
+++ b/Mozilla/Firefox/Install.ps1
@@ -19,7 +19,7 @@ Update-Module Evergreen
 
 $Vendor = "Mozilla"
 $Product = "FireFox"
-$Evergreen = Get-MozillaFirefox -Platform win64
+$Evergreen = Get-MozillaFirefox -Platform win64 | Where-Object -Property Version -NotLike "*esr*"
 $Version = $Evergreen.Version
 $URL = $Evergreen.uri
 $PackageName = "Firefox"


### PR DESCRIPTION
Due to the change in the Evergreen module, the get command returns two version.
https://github.com/aaronparker/Evergreen/pull/68#issue-428103135
This where query is an example to filter this back to one result.