### PR TITLE
Fix UnattendedArgs syntax

### DIFF
--- a/Mozilla/Firefox/Install.ps1
+++ b/Mozilla/Firefox/Install.ps1
@@ -29,7 +29,7 @@ $Source = "$PackageName" + "." + "$InstallerType"
 $LogPS = "${env:SystemRoot}" + "\Temp\$Vendor $Product $Version PS Wrapper.log"
 $LogApp = "${env:SystemRoot}" + "\Temp\$PackageName.log"
 $Destination = "${env:ChocoRepository}" + "\$Vendor\$Product\$Version\$packageName.$installerType"
-$UnattendedArgs = '-ms MaintenanceService=false'
+$UnattendedArgs = '/S /MaintenanceService=false'
 $ProgressPreference = 'SilentlyContinue'
 
 Start-Transcript $LogPS | Out-Null


### PR DESCRIPTION
Mozilla changed the syntax for the arguments, Each option must start with a / as shown, - or -- are not supported:
https://firefox-source-docs.mozilla.org/browser/installer/windows/installer/FullConfig.html